### PR TITLE
Alert user of runtime error if they happen inside of the provided Sta…

### DIFF
--- a/src/components/StatefulCard.js
+++ b/src/components/StatefulCard.js
@@ -47,10 +47,22 @@ export default class StatefulCard extends Component {
   }
   render() {
     const {title, doc} = this.props
+    
+    let children
+    try {
+      children = this.props.children(this.control)
+    } catch(err) {
+      /* 
+         Can't `throw new Error()`, It's swallowed by something
+         This is at least informative
+      */
+      console.error(err) 
+    }
+    
     return (
       <Card {...{title, doc}}>
       {this.props.history ? this.renderHistoryControl() : null}
-      {this.props.children(this.control)}
+      {children}
       {this.props.inspect ? this.renderInspect() : null}
       </Card>
     )


### PR DESCRIPTION
…tefulCard function

I love this repo and rely on it heavily. I find if I'm doing setup, or just regular code before returning jsx from the card's function, the errors are super vague and all my errors are swallowed. This change saves me hours of needle haystack hunting.