### PR TITLE
Change react and react-dom to externals in webpack and peer dependencies in package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactcards",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "devcards for react",
   "license": "BSD-3-Clause",
   "main": "dist/client.bundle.js",
@@ -21,7 +21,10 @@
   },
   "devDependencies": {
     "commander": "^2.9.0",
-    "istanbul": "^1.0.0-alpha"
+    "istanbul": "^1.0.0-alpha",
+    "react-addons-test-utils": "^15.3.0",
+    "react": "^15.0.0",
+    "react-dom": "^15.3.0"
   },
   "dependencies": {
     "babel-cli": "^6.9.0",
@@ -49,9 +52,6 @@
     "mocha": "^2.4.5",
     "myro": "^0.6.2",
     "postcss-loader": "^0.9.1",
-    "react": "^15.3.0",
-    "react-addons-test-utils": "^15.3.0",
-    "react-dom": "^15.3.0",
     "react-hot-loader": "^3.0.0-alpha.8",
     "showdown": "^1.3.0",
     "sinon": "^1.17.4",
@@ -59,6 +59,10 @@
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.14.1",
     "webpack-hot-middleware": "^2.10.0"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-dom": "*"
   },
   "bin": {
     "reactcards": "./dist/server.js"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,10 @@ module.exports = {
         filename: "app.js",
         path: path.join(__dirname, "public")
     },
-
+    externals: {
+      "react": "react",
+      "react-dom": "react-dom"
+    },
     module: {
         loaders: [
             {

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -12,7 +12,10 @@ module.exports = {
         library: 'reactcards',
         libraryTarget: 'umd'
     },
-
+    externals: {
+        "react": "react",
+        "react-dom": "react-dom"
+    },
     module: {
         loaders: [
             {


### PR DESCRIPTION
Under the current version of reactcards, any components that use `refs` will cause the following error ```Uncaught Error: addComponentAsRefTo(...): Only a ReactOwner can have refs. You might be adding a ref to a component that was not created inside a component's `render` method, or you have multiple copies of React loaded.``` This is due to the fact that the library uses its own internal versions of react and react-dom, causing a collision. By changing these to externals and peer dependencies, we allow the library to access whatever versions the user currently has installed in node_modules averting this error.