### PR TITLE
fix typo in OccurrenceOrderPlugin

### DIFF
--- a/src/server/webpack.config.js
+++ b/src/server/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
         publicPath: '/public'
     },
     plugins: [
-        new webpack.optimize.OccurenceOrderPlugin(),
+        new webpack.optimize.OccurrenceOrderPlugin(),
         new webpack.HotModuleReplacementPlugin()
     ],
 


### PR DESCRIPTION
This a fix for the following error: `TypeError: webpack.optimize.OccurenceOrderPlugin is not a constructor`

I am getting this error with Webpack version 3.4.1, but it looks like it will also happen with earlier versions:
https://github.com/webpack/webpack/issues/1964

An alternative solution would be removing this plugin altogether, since it does not appear to be needed anymore: https://gist.github.com/sokra/27b24881210b56bbaff7#occurrence-order

